### PR TITLE
feat: added QUIET env variable support

### DIFF
--- a/bin/mv3-hot-reload.ts
+++ b/bin/mv3-hot-reload.ts
@@ -16,6 +16,7 @@ interface Config {
 let port = 9012
 let directory = 'dist'
 let exclude: string[] = []
+const quiet = !!process.env.QUIET
 
 try {
   const CONFIG_PATH = path.resolve('mv3-hot-reload.config.js')
@@ -51,7 +52,9 @@ wss.on('connection', (ws) => {
       'all',
       debounce((_, path) => {
         if (!excludePaths.includes(path)) {
-          console.log('file change detected.')
+          if (!quiet) {
+            console.log('file change detected.')
+          }
           ws.send(Message.FileChange)
         }
       }, 500),


### PR DESCRIPTION
Thanks for nice plugin!
It would be great if it were possible to turn off tons of
```bash
[watch:dist] file change detected.
[watch:dist] file change detected.
[watch:dist] file change detected.
[watch:dist] file change detected.
[watch:dist] file change detected.
[watch:dist] file change detected.
[watch:dist] file change detected.
[watch:dist] file change detected.
...
```